### PR TITLE
Remove local drush-node dep, replace with npm repo module

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/aquifer/aquifer-drush",
   "dependencies": {
-    "drush-node": "^0.1.3",
+    "drush-node": "chasingmaxwell/drush-node",
     "jsonfile": "^2.2.1",
     "path": "^0.11.14",
     "q": "^1.4.1"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/aquifer/aquifer-drush",
   "dependencies": {
-    "drush-node": "file:../../../../tmp/npm-26336-97fe77b2/git-cache-bb1ddf0a6c5b/abd5ce7d4fa75d7d115edab20b32f9af945fa229",
+    "drush-node": "^0.1.3",
     "jsonfile": "^2.2.1",
     "path": "^0.11.14",
     "q": "^1.4.1"


### PR DESCRIPTION
This PR removes the drush-node dependency that had a local reference, and replaces it with drush node from the npm repositories.
